### PR TITLE
Cleaning up entrypoints - removing circular dependency and adding

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Using manage.py as main entrypoint to app by forwarding the typical
+# "manage.py" commands off to flask's utlitiy script.
+echo "Forwarding command to flask utility script"
+echo
+echo "  FLASK_APP=psi.cli:application flask $@"
+echo
+exec env FLASK_APP=psi.cli:application flask $@

--- a/psi/cli.py
+++ b/psi/cli.py
@@ -1,11 +1,15 @@
 import sys
-from psi.wsgi import application
+from psi.app import create_app
+
+
+# Using flask's default `click` command line environment
+application = create_app()
 
 
 @application.cli.command()
 def test():
     """Run the unit tests.
-    >>> export FLASK_APP=manage:application
+    >>> export FLASK_APP=psi.cli:application
     >>> flask test
     """
     import subprocess

--- a/psi/wsgi.py
+++ b/psi/wsgi.py
@@ -1,20 +1,27 @@
 # coding=utf-8
+import sys
+import os
 
-import sys, os
 
-sys.path.insert(0, os.getcwd() + "/psi")
-
-# This import should behind above two lines
-# To avoid Chinese character display issue
-from psi.app import create_app, init_all
+try:
+    # This import should behind above two lines
+    # To avoid Chinese character display issue
+    from psi.app import create_app, init_all
+except ImportError:
+    # If os.getcwd() is _inside_ the psi package, add parent directory
+    # to front of PATH so the interpreter can import the `psi` package
+    _this_dir = os.path.dirname(os.path.realpath(__file__))
+    _root_dir = os.path.join(this_dir, '..')
+    sys.path.insert(0, _root_dir)
+    # Try the import again!
+    from psi.app import create_app, init_all
 
 
 application = create_app()
 socket_io = init_all(application)
 
+
 if __name__ == '__main__':
-    application.run(threaded=True, debug=True)
-
-
-from psi.cli import (test, generate_fake_order, clean_database,
-                     clean_transaction_data)
+    host = sys.environ.get('PSI_HOST')
+    port = sys.environ.get('PSI_PORT', 5000)
+    application.run(threaded=True, debug=True, host=host, port=port)


### PR DESCRIPTION
There was a circular dependency between `psi/cli.py` and `psi/wsgi.py`. I fixed it and added some comments inline for more explanation.

Additionally, I added a "manage.py" script to forward commands to the flask utility script. Some of the documentation still references `./manage.py` and it's a common python codebase pattern that it seemed reasonable to have keep the script